### PR TITLE
update scala version setting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.16, 2.13.9, 3.2.0]
+        scala: [2.12.x, 2.13.x, 3.x]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
use sbt 1.7 new feature

https://github.com/sbt/sbt/releases/tag/v1.7.0

> ++ command updates
> Prior to sbt 1.7 ++ <sv> <command1> filtered subprojects using crossScalaVersions having the same ABI suffix as <sv>. This behavior was generally not well understood, and also created incorrect result for Scala 3.x since ++ 3.0.1 test could downgrade subproject that may require 3.1 or above.
>
> sbt 1.7.0 fixes this by requiring ++ <sv> <command1> so <sv> part can be given as a [semantic version selector](https://github.com/npm/node-semver) expression, such as 3.1.x or 2.13.x. Note that the expression may match at most one Scala version to switch into. In sbt 1.7.0, a concrete version such as ++ 3.0.1 equires exact version to be present in crossScalaVersion.